### PR TITLE
Use exported datastream merge functions, skip partial on cache miss

### DIFF
--- a/async_handler.go
+++ b/async_handler.go
@@ -11,6 +11,7 @@ import (
 	schematicdatastreamws "github.com/schematichq/schematic-datastream-ws"
 	schematicgo "github.com/schematichq/schematic-go"
 	"github.com/schematichq/schematic-go/client"
+	"github.com/schematichq/schematic-go/datastream"
 )
 
 // CircuitBreakerState represents the state of a circuit breaker
@@ -565,37 +566,49 @@ func (h *AsyncReplicatorMessageHandler) processBatchedCompanyMessages(ctx contex
 	}
 
 	// Group operations by type for better batching
-	var creates []*rulesengine.Company
+	var fulls []*rulesengine.Company
+	var partials []*MessageJob
 	var deletes []*rulesengine.Company
 
 	for _, job := range jobs {
-		company, err := h.parseCompanyMessage(job.Message)
-		if err != nil {
-			h.logger.Error(ctx, fmt.Sprintf("Failed to parse company message: %v", err))
-			continue
-		}
-
-		if company == nil {
-			continue
-		}
-
 		switch job.Message.MessageType {
-		case schematicdatastreamws.MessageTypeFull, schematicdatastreamws.MessageTypePartial:
-			creates = append(creates, company)
+		case schematicdatastreamws.MessageTypeFull:
+			company, err := h.parseCompanyMessage(job.Message)
+			if err != nil {
+				h.logger.Error(ctx, fmt.Sprintf("Failed to parse company message: %v", err))
+				continue
+			}
+			if company != nil {
+				fulls = append(fulls, company)
+			}
+		case schematicdatastreamws.MessageTypePartial:
+			partials = append(partials, job)
 		case schematicdatastreamws.MessageTypeDelete:
-			deletes = append(deletes, company)
+			company, err := h.parseCompanyMessage(job.Message)
+			if err != nil {
+				h.logger.Error(ctx, fmt.Sprintf("Failed to parse company message: %v", err))
+				continue
+			}
+			if company != nil {
+				deletes = append(deletes, company)
+			}
 		}
 	}
 
-	// Batch create operations
-	if len(creates) > 0 {
-		if err := h.batchCacheCompanies(ctx, creates); err != nil {
+	// Batch full create/update operations
+	if len(fulls) > 0 {
+		if err := h.batchCacheCompanies(ctx, fulls); err != nil {
 			h.redisCircuitBreaker.RecordFailure()
 			h.logger.Error(ctx, fmt.Sprintf("Batch company cache failed: %v", err))
 		} else {
 			h.redisCircuitBreaker.RecordSuccess()
-			h.logger.Debug(ctx, fmt.Sprintf("Successfully cached %d companies", len(creates)))
+			h.logger.Debug(ctx, fmt.Sprintf("Successfully cached %d companies", len(fulls)))
 		}
+	}
+
+	// Process partial updates individually (read-modify-write)
+	if len(partials) > 0 {
+		h.processPartialCompanyMessages(ctx, partials)
 	}
 
 	// Batch delete operations
@@ -621,36 +634,48 @@ func (h *AsyncReplicatorMessageHandler) processBatchedUserMessages(ctx context.C
 		return
 	}
 
-	var creates []*rulesengine.User
+	var fulls []*rulesengine.User
+	var partials []*MessageJob
 	var deletes []*rulesengine.User
 
 	for _, job := range jobs {
-		user, err := h.parseUserMessage(job.Message)
-		if err != nil {
-			h.logger.Error(ctx, fmt.Sprintf("Failed to parse user message: %v", err))
-			continue
-		}
-
-		if user == nil {
-			continue
-		}
-
 		switch job.Message.MessageType {
-		case schematicdatastreamws.MessageTypeFull, schematicdatastreamws.MessageTypePartial:
-			creates = append(creates, user)
+		case schematicdatastreamws.MessageTypeFull:
+			user, err := h.parseUserMessage(job.Message)
+			if err != nil {
+				h.logger.Error(ctx, fmt.Sprintf("Failed to parse user message: %v", err))
+				continue
+			}
+			if user != nil {
+				fulls = append(fulls, user)
+			}
+		case schematicdatastreamws.MessageTypePartial:
+			partials = append(partials, job)
 		case schematicdatastreamws.MessageTypeDelete:
-			deletes = append(deletes, user)
+			user, err := h.parseUserMessage(job.Message)
+			if err != nil {
+				h.logger.Error(ctx, fmt.Sprintf("Failed to parse user message: %v", err))
+				continue
+			}
+			if user != nil {
+				deletes = append(deletes, user)
+			}
 		}
 	}
 
-	if len(creates) > 0 {
-		if err := h.batchCacheUsers(ctx, creates); err != nil {
+	if len(fulls) > 0 {
+		if err := h.batchCacheUsers(ctx, fulls); err != nil {
 			h.redisCircuitBreaker.RecordFailure()
 			h.logger.Error(ctx, fmt.Sprintf("Batch user cache failed: %v", err))
 		} else {
 			h.redisCircuitBreaker.RecordSuccess()
-			h.logger.Debug(ctx, fmt.Sprintf("Successfully cached %d users", len(creates)))
+			h.logger.Debug(ctx, fmt.Sprintf("Successfully cached %d users", len(fulls)))
 		}
+	}
+
+	// Process partial updates individually (read-modify-write)
+	if len(partials) > 0 {
+		h.processPartialUserMessages(ctx, partials)
 	}
 
 	if len(deletes) > 0 {
@@ -662,6 +687,92 @@ func (h *AsyncReplicatorMessageHandler) processBatchedUserMessages(ctx context.C
 			h.logger.Debug(ctx, fmt.Sprintf("Successfully deleted %d users", len(deletes)))
 		}
 	}
+}
+
+// processPartialCompanyMessages handles partial company updates individually via read-modify-write.
+func (h *AsyncReplicatorMessageHandler) processPartialCompanyMessages(ctx context.Context, jobs []*MessageJob) {
+	for _, job := range jobs {
+		id, err := datastream.ExtractIDFromJSON(job.Message.Data)
+		if err != nil {
+			h.logger.Error(ctx, fmt.Sprintf("Failed to extract company ID from partial message: %v", err))
+			continue
+		}
+
+		h.companyMu.Lock()
+		existing, existErr := h.companiesCache.Get(ctx, companyIDCacheKey(id))
+		if existErr != nil || existing == nil {
+			h.companyMu.Unlock()
+			h.logger.Warn(ctx, fmt.Sprintf("Cache miss for partial company '%s', skipping", id))
+			continue
+		}
+		company, mergeErr := datastream.PartialCompany(existing, job.Message.Data)
+		if mergeErr != nil {
+			h.companyMu.Unlock()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to merge partial company '%s': %v", id, mergeErr))
+			continue
+		}
+
+		idKey := companyIDCacheKey(company.ID)
+		if err := h.companiesCache.Set(ctx, idKey, company, h.cacheTTL); err != nil {
+			h.companyMu.Unlock()
+			h.redisCircuitBreaker.RecordFailure()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to cache partial company '%s': %v", id, err))
+			continue
+		}
+		for key, value := range company.Keys {
+			lookupKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
+			if err := h.companyLookupCache.Set(ctx, lookupKey, company.ID, h.cacheTTL); err != nil {
+				h.logger.Warn(ctx, fmt.Sprintf("Failed to cache company lookup key '%s': %v", lookupKey, err))
+			}
+		}
+		h.companyMu.Unlock()
+		h.redisCircuitBreaker.RecordSuccess()
+	}
+
+	h.logger.Debug(ctx, fmt.Sprintf("Processed %d partial company messages", len(jobs)))
+}
+
+// processPartialUserMessages handles partial user updates individually via read-modify-write.
+func (h *AsyncReplicatorMessageHandler) processPartialUserMessages(ctx context.Context, jobs []*MessageJob) {
+	for _, job := range jobs {
+		id, err := datastream.ExtractIDFromJSON(job.Message.Data)
+		if err != nil {
+			h.logger.Error(ctx, fmt.Sprintf("Failed to extract user ID from partial message: %v", err))
+			continue
+		}
+
+		h.userMu.Lock()
+		existing, existErr := h.usersCache.Get(ctx, userIDCacheKey(id))
+		if existErr != nil || existing == nil {
+			h.userMu.Unlock()
+			h.logger.Warn(ctx, fmt.Sprintf("Cache miss for partial user '%s', skipping", id))
+			continue
+		}
+		user, mergeErr := datastream.PartialUser(existing, job.Message.Data)
+		if mergeErr != nil {
+			h.userMu.Unlock()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to merge partial user '%s': %v", id, mergeErr))
+			continue
+		}
+
+		idKey := userIDCacheKey(user.ID)
+		if err := h.usersCache.Set(ctx, idKey, user, h.cacheTTL); err != nil {
+			h.userMu.Unlock()
+			h.redisCircuitBreaker.RecordFailure()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to cache partial user '%s': %v", id, err))
+			continue
+		}
+		for key, value := range user.Keys {
+			lookupKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
+			if err := h.userLookupCache.Set(ctx, lookupKey, user.ID, h.cacheTTL); err != nil {
+				h.logger.Warn(ctx, fmt.Sprintf("Failed to cache user lookup key '%s': %v", lookupKey, err))
+			}
+		}
+		h.userMu.Unlock()
+		h.redisCircuitBreaker.RecordSuccess()
+	}
+
+	h.logger.Debug(ctx, fmt.Sprintf("Processed %d partial user messages", len(jobs)))
 }
 
 // processBatchedFlagsMessages processes a batch of flags messages with circuit breaker

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/schematichq/rulesengine v0.1.14
 	github.com/schematichq/schematic-datastream-ws v0.2.7
-	github.com/schematichq/schematic-go v1.4.3
+	github.com/schematichq/schematic-go v1.4.4-0.20260316174403-f539b4e4a607
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/schematichq/rulesengine v0.1.14 h1:lCBfBwxxvsF9OkcPrnP6c1y4hGAHEzr3ac
 github.com/schematichq/rulesengine v0.1.14/go.mod h1:HmweBgjg+kVe6VuNMLc7FISHFF0wzr5cVGLAxlVP8+4=
 github.com/schematichq/schematic-datastream-ws v0.2.7 h1:8dTVii0ALVTlO3lcR2tnGePBLSrmMYVTjy6QB+g8TVQ=
 github.com/schematichq/schematic-datastream-ws v0.2.7/go.mod h1:NKrg326C9YfCDOI84On5GZhvrovzDpFCzW8wdBwPZ3g=
-github.com/schematichq/schematic-go v1.4.3 h1:OPVYx9XzNg/9+nwbUZAiZzKIsUeuPcSY2PPMDYnbt0o=
-github.com/schematichq/schematic-go v1.4.3/go.mod h1:E9KEzNmmRebEraW7rYDC1tPysUCpoKIO9yU3lsDeonA=
+github.com/schematichq/schematic-go v1.4.4-0.20260316174403-f539b4e4a607 h1:gEbs9oZ9EjgLXaztq10mpmLXX/cwFuDkASZHp20mf3s=
+github.com/schematichq/schematic-go v1.4.4-0.20260316174403-f539b4e4a607/go.mod h1:E9KEzNmmRebEraW7rYDC1tPysUCpoKIO9yU3lsDeonA=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/handlers.go
+++ b/handlers.go
@@ -12,6 +12,7 @@ import (
 	schematicdatastreamws "github.com/schematichq/schematic-datastream-ws"
 	schematicgo "github.com/schematichq/schematic-go"
 	"github.com/schematichq/schematic-go/client"
+	"github.com/schematichq/schematic-go/datastream"
 )
 
 // ReplicatorMessageHandler implements the MessageHandler interface
@@ -221,8 +222,7 @@ func (h *ReplicatorMessageHandler) handleFlagMessage(ctx context.Context, messag
 func (h *ReplicatorMessageHandler) handleCompanyMessage(ctx context.Context, message *schematicdatastreamws.DataStreamResp) error {
 	h.logger.Debug(ctx, fmt.Sprintf("Received company message: %v", message))
 	switch message.MessageType {
-	case schematicdatastreamws.MessageTypeFull, schematicdatastreamws.MessageTypePartial:
-		// Data comes as rulesengine.Company directly
+	case schematicdatastreamws.MessageTypeFull:
 		var company *rulesengine.Company
 		if err := json.Unmarshal(message.Data, &company); err != nil {
 			h.logger.Error(ctx, fmt.Sprintf("Failed to unmarshal company data: %v", err))
@@ -233,12 +233,10 @@ func (h *ReplicatorMessageHandler) handleCompanyMessage(ctx context.Context, mes
 			return nil
 		}
 
-		// Lock for cache operations and cache company for all keys (matching schematic-go pattern)
 		h.companyMu.Lock()
 		cacheResults := h.cacheCompanyForKeys(ctx, company)
 		h.companyMu.Unlock()
 
-		// Check for cache errors and log warnings (non-blocking like schematic-go)
 		for cacheKey, cacheErr := range cacheResults {
 			if cacheErr != nil {
 				h.logger.Warn(ctx, fmt.Sprintf("Cache error for company key '%s': %v", cacheKey, cacheErr))
@@ -247,6 +245,39 @@ func (h *ReplicatorMessageHandler) handleCompanyMessage(ctx context.Context, mes
 
 		if len(cacheResults) > 0 {
 			h.logger.Debug(ctx, fmt.Sprintf("Cached company with %d keys: %s", len(cacheResults), company.ID))
+		}
+
+	case schematicdatastreamws.MessageTypePartial:
+		id, err := datastream.ExtractIDFromJSON(message.Data)
+		if err != nil {
+			h.logger.Error(ctx, fmt.Sprintf("Failed to extract company ID from partial message: %v", err))
+			return err
+		}
+
+		h.companyMu.Lock()
+		existing, existErr := h.companiesCache.Get(ctx, companyIDCacheKey(id))
+		if existErr != nil || existing == nil {
+			h.companyMu.Unlock()
+			h.logger.Warn(ctx, fmt.Sprintf("Cache miss for partial company '%s', skipping", id))
+			return nil
+		}
+		company, mergeErr := datastream.PartialCompany(existing, message.Data)
+		if mergeErr != nil {
+			h.companyMu.Unlock()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to merge partial company: %v", mergeErr))
+			return mergeErr
+		}
+		cacheResults := h.cacheCompanyForKeys(ctx, company)
+		h.companyMu.Unlock()
+
+		for cacheKey, cacheErr := range cacheResults {
+			if cacheErr != nil {
+				h.logger.Warn(ctx, fmt.Sprintf("Cache error for company key '%s': %v", cacheKey, cacheErr))
+			}
+		}
+
+		if len(cacheResults) > 0 {
+			h.logger.Debug(ctx, fmt.Sprintf("Cached partial company with %d keys: %s", len(cacheResults), company.ID))
 		}
 
 	case schematicdatastreamws.MessageTypeDelete:
@@ -330,8 +361,7 @@ func (h *ReplicatorMessageHandler) cacheUserForKeys(ctx context.Context, user *r
 // User handling
 func (h *ReplicatorMessageHandler) handleUserMessage(ctx context.Context, message *schematicdatastreamws.DataStreamResp) error {
 	switch message.MessageType {
-	case schematicdatastreamws.MessageTypeFull, schematicdatastreamws.MessageTypePartial:
-		// Data comes as rulesengine.User directly
+	case schematicdatastreamws.MessageTypeFull:
 		var user *rulesengine.User
 		if err := json.Unmarshal(message.Data, &user); err != nil {
 			h.logger.Error(ctx, fmt.Sprintf("Failed to unmarshal user data: %v", err))
@@ -342,12 +372,10 @@ func (h *ReplicatorMessageHandler) handleUserMessage(ctx context.Context, messag
 			return nil
 		}
 
-		// Lock for cache operations and cache user for all keys (matching schematic-go pattern)
 		h.userMu.Lock()
 		cacheResults := h.cacheUserForKeys(ctx, user)
 		h.userMu.Unlock()
 
-		// Check for cache errors and log warnings (non-blocking like schematic-go)
 		for cacheKey, cacheErr := range cacheResults {
 			if cacheErr != nil {
 				h.logger.Warn(ctx, fmt.Sprintf("Cache error for user key '%s': %v", cacheKey, cacheErr))
@@ -358,8 +386,40 @@ func (h *ReplicatorMessageHandler) handleUserMessage(ctx context.Context, messag
 			h.logger.Debug(ctx, fmt.Sprintf("Cached user with %d keys: %s", len(cacheResults), user.ID))
 		}
 
+	case schematicdatastreamws.MessageTypePartial:
+		id, err := datastream.ExtractIDFromJSON(message.Data)
+		if err != nil {
+			h.logger.Error(ctx, fmt.Sprintf("Failed to extract user ID from partial message: %v", err))
+			return err
+		}
+
+		h.userMu.Lock()
+		existing, existErr := h.usersCache.Get(ctx, userIDCacheKey(id))
+		if existErr != nil || existing == nil {
+			h.userMu.Unlock()
+			h.logger.Warn(ctx, fmt.Sprintf("Cache miss for partial user '%s', skipping", id))
+			return nil
+		}
+		user, mergeErr := datastream.PartialUser(existing, message.Data)
+		if mergeErr != nil {
+			h.userMu.Unlock()
+			h.logger.Error(ctx, fmt.Sprintf("Failed to merge partial user: %v", mergeErr))
+			return mergeErr
+		}
+		cacheResults := h.cacheUserForKeys(ctx, user)
+		h.userMu.Unlock()
+
+		for cacheKey, cacheErr := range cacheResults {
+			if cacheErr != nil {
+				h.logger.Warn(ctx, fmt.Sprintf("Cache error for user key '%s': %v", cacheKey, cacheErr))
+			}
+		}
+
+		if len(cacheResults) > 0 {
+			h.logger.Debug(ctx, fmt.Sprintf("Cached partial user with %d keys: %s", len(cacheResults), user.ID))
+		}
+
 	case schematicdatastreamws.MessageTypeDelete:
-		// For delete, expect user data with keys (matching schematic-go)
 		var user *rulesengine.User
 		if err := json.Unmarshal(message.Data, &user); err != nil {
 			h.logger.Error(ctx, fmt.Sprintf("Failed to unmarshal user delete data: %v", err))

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -48,6 +48,37 @@ func (m *MockCacheProvider[T]) DeleteByPattern(ctx context.Context, pattern stri
 	return args.Int(0), args.Error(1)
 }
 
+// testHarness bundles the mocks and handler used by every message-handler test.
+type testHarness struct {
+	handler            *ReplicatorMessageHandler
+	companyCache       *MockCacheProvider[*rulesengine.Company]
+	companyLookupCache *MockCacheProvider[string]
+	userCache          *MockCacheProvider[*rulesengine.User]
+	userLookupCache    *MockCacheProvider[string]
+	flagCache          *MockCacheProvider[*rulesengine.Flag]
+}
+
+func newTestHarness(t *testing.T) *testHarness {
+	t.Helper()
+	h := &testHarness{
+		companyCache:       NewMockCacheProvider[*rulesengine.Company](),
+		companyLookupCache: NewMockCacheProvider[string](),
+		userCache:          NewMockCacheProvider[*rulesengine.User](),
+		userLookupCache:    NewMockCacheProvider[string](),
+		flagCache:          NewMockCacheProvider[*rulesengine.Flag](),
+	}
+	h.handler = NewReplicatorMessageHandler(
+		NewSchematicLogger(),
+		h.companyCache,
+		h.companyLookupCache,
+		h.userCache,
+		h.userLookupCache,
+		h.flagCache,
+		5*time.Minute,
+	)
+	return h
+}
+
 // Test data helpers
 func createTestCompany(t *testing.T) *rulesengine.Company {
 	t.Helper()
@@ -143,26 +174,8 @@ func TestReplicatorMessageHandler_HandleCompanyMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mocks
-			logger := NewSchematicLogger()
-			mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-			mockCompanyLookupCache := NewMockCacheProvider[string]()
-			mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-			mockUserLookupCache := NewMockCacheProvider[string]()
-			mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+			h := newTestHarness(t)
 
-			// Create handler
-			handler := NewReplicatorMessageHandler(
-				logger,
-				mockCompanyCache,
-				mockCompanyLookupCache,
-				mockUserCache,
-				mockUserLookupCache,
-				mockFlagCache,
-				5*time.Minute,
-			)
-
-			// Prepare test data
 			companyData, err := json.Marshal(tt.company)
 			assert.NoError(t, err)
 
@@ -175,39 +188,36 @@ func TestReplicatorMessageHandler_HandleCompanyMessage(t *testing.T) {
 			// Setup expectations
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
 				idKey := companyIDCacheKey(tt.company.ID)
-				mockCompanyCache.On("Delete", mock.Anything, idKey).Return(nil)
+				h.companyCache.On("Delete", mock.Anything, idKey).Return(nil)
 				for key, value := range tt.company.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
-					mockCompanyLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
+					h.companyLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
 				}
 			} else if tt.messageType == schematicdatastreamws.MessageTypePartial {
 				// Partial with cache miss: expect Get (not found), skip without Set
 				idKey := companyIDCacheKey(tt.company.ID)
 				var nilCompany *rulesengine.Company
-				mockCompanyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found"))
+				h.companyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found"))
 			} else {
 				idKey := companyIDCacheKey(tt.company.ID)
-				mockCompanyCache.On("Set", mock.Anything, idKey, tt.company, 5*time.Minute).Return(nil)
+				h.companyCache.On("Set", mock.Anything, idKey, tt.company, 5*time.Minute).Return(nil)
 				for key, value := range tt.company.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
-					mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, tt.company.ID, 5*time.Minute).Return(nil)
+					h.companyLookupCache.On("Set", mock.Anything, cacheKey, tt.company.ID, 5*time.Minute).Return(nil)
 				}
 			}
 
-			// Execute test
 			ctx := context.Background()
-			err = handler.HandleMessage(ctx, message)
+			err = h.handler.HandleMessage(ctx, message)
 
-			// Verify results
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
 
-			// Verify mock expectations
-			mockCompanyCache.AssertExpectations(t)
-			mockCompanyLookupCache.AssertExpectations(t)
+			h.companyCache.AssertExpectations(t)
+			h.companyLookupCache.AssertExpectations(t)
 		})
 	}
 }
@@ -241,26 +251,8 @@ func TestReplicatorMessageHandler_HandleUserMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mocks
-			logger := NewSchematicLogger()
-			mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-			mockCompanyLookupCache := NewMockCacheProvider[string]()
-			mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-			mockUserLookupCache := NewMockCacheProvider[string]()
-			mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+			h := newTestHarness(t)
 
-			// Create handler
-			handler := NewReplicatorMessageHandler(
-				logger,
-				mockCompanyCache,
-				mockCompanyLookupCache,
-				mockUserCache,
-				mockUserLookupCache,
-				mockFlagCache,
-				5*time.Minute,
-			)
-
-			// Prepare test data
 			userData, err := json.Marshal(tt.user)
 			assert.NoError(t, err)
 
@@ -270,42 +262,37 @@ func TestReplicatorMessageHandler_HandleUserMessage(t *testing.T) {
 				Data:        json.RawMessage(userData),
 			}
 
-			// Setup expectations based on message type
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
 				idKey := userIDCacheKey(tt.user.ID)
-				mockUserCache.On("Delete", mock.Anything, idKey).Return(nil)
+				h.userCache.On("Delete", mock.Anything, idKey).Return(nil)
 				for key, value := range tt.user.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
-					mockUserLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
+					h.userLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
 				}
 			} else if tt.messageType == schematicdatastreamws.MessageTypePartial {
-				// Partial with cache miss: expect Get (not found), skip without Set
 				idKey := userIDCacheKey(tt.user.ID)
 				var nilUser *rulesengine.User
-				mockUserCache.On("Get", mock.Anything, idKey).Return(nilUser, fmt.Errorf("not found"))
+				h.userCache.On("Get", mock.Anything, idKey).Return(nilUser, fmt.Errorf("not found"))
 			} else {
 				idKey := userIDCacheKey(tt.user.ID)
-				mockUserCache.On("Set", mock.Anything, idKey, tt.user, 5*time.Minute).Return(nil)
+				h.userCache.On("Set", mock.Anything, idKey, tt.user, 5*time.Minute).Return(nil)
 				for key, value := range tt.user.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
-					mockUserLookupCache.On("Set", mock.Anything, cacheKey, tt.user.ID, 5*time.Minute).Return(nil)
+					h.userLookupCache.On("Set", mock.Anything, cacheKey, tt.user.ID, 5*time.Minute).Return(nil)
 				}
 			}
 
-			// Execute test
 			ctx := context.Background()
-			err = handler.HandleMessage(ctx, message)
+			err = h.handler.HandleMessage(ctx, message)
 
-			// Verify results
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
 
-			// Verify mock expectations
-			mockUserCache.AssertExpectations(t)
-			mockUserLookupCache.AssertExpectations(t)
+			h.userCache.AssertExpectations(t)
+			h.userLookupCache.AssertExpectations(t)
 		})
 	}
 }
@@ -339,47 +326,21 @@ func TestReplicatorMessageHandler_HandleFlagMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mocks
-			logger := NewSchematicLogger()
-			mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-			mockCompanyLookupCache := NewMockCacheProvider[string]()
-			mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-			mockUserLookupCache := NewMockCacheProvider[string]()
-			mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+			h := newTestHarness(t)
 
-			// Create handler
-			handler := NewReplicatorMessageHandler(
-				logger,
-				mockCompanyCache,
-				mockCompanyLookupCache,
-				mockUserCache,
-				mockUserLookupCache,
-				mockFlagCache,
-				5*time.Minute,
-			)
-
-			// Prepare test data
 			var message *schematicdatastreamws.DataStreamResp
-
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
-				// For delete messages, we expect just the flag key/ID
-				deleteData := map[string]string{
-					"key": tt.flag.Key,
-					"id":  tt.flag.ID,
-				}
+				deleteData := map[string]string{"key": tt.flag.Key, "id": tt.flag.ID}
 				flagData, err := json.Marshal(deleteData)
 				assert.NoError(t, err)
-
 				message = &schematicdatastreamws.DataStreamResp{
 					EntityType:  string(schematicdatastreamws.EntityTypeFlag),
 					MessageType: tt.messageType,
 					Data:        json.RawMessage(flagData),
 				}
 			} else {
-				// For create/update messages, we expect the full flag
 				flagData, err := json.Marshal(tt.flag)
 				assert.NoError(t, err)
-
 				message = &schematicdatastreamws.DataStreamResp{
 					EntityType:  string(schematicdatastreamws.EntityTypeFlag),
 					MessageType: tt.messageType,
@@ -387,57 +348,32 @@ func TestReplicatorMessageHandler_HandleFlagMessage(t *testing.T) {
 				}
 			}
 
-			// Setup expectations
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
-				// For delete operations, expect Delete call for the flag
 				cacheKey := flagCacheKey(tt.flag.Key)
-				mockFlagCache.On("Delete", mock.Anything, cacheKey).Return(nil)
+				h.flagCache.On("Delete", mock.Anything, cacheKey).Return(nil)
 			} else {
-				// For create/update operations, expect Set call for the flag
-				// Note: Single flag processing should NOT call DeleteMissing
 				cacheKey := flagCacheKey(tt.flag.Key)
-				mockFlagCache.On("Set", mock.Anything, cacheKey, tt.flag, 5*time.Minute).Return(nil)
+				h.flagCache.On("Set", mock.Anything, cacheKey, tt.flag, 5*time.Minute).Return(nil)
 			}
 
-			// Execute test
 			ctx := context.Background()
-			err := handler.HandleMessage(ctx, message)
+			err := h.handler.HandleMessage(ctx, message)
 
-			// Verify results
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
 
-			// Verify mock expectations
-			mockFlagCache.AssertExpectations(t)
+			h.flagCache.AssertExpectations(t)
 		})
 	}
 }
 
 func TestReplicatorMessageHandler_HandleFlagsMessage(t *testing.T) {
 	t.Run("Handle bulk flags message with DeleteMissing", func(t *testing.T) {
-		// Create mocks
-		logger := NewSchematicLogger()
-		mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-		mockCompanyLookupCache := NewMockCacheProvider[string]()
-		mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-		mockUserLookupCache := NewMockCacheProvider[string]()
-		mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+		h := newTestHarness(t)
 
-		// Create handler
-		handler := NewReplicatorMessageHandler(
-			logger,
-			mockCompanyCache,
-			mockCompanyLookupCache,
-			mockUserCache,
-			mockUserLookupCache,
-			mockFlagCache,
-			5*time.Minute,
-		)
-
-		// Prepare test data - multiple flags
 		flags := []*rulesengine.Flag{
 			createTestFlag(t),
 			{
@@ -458,51 +394,25 @@ func TestReplicatorMessageHandler_HandleFlagsMessage(t *testing.T) {
 			Data:        json.RawMessage(flagsData),
 		}
 
-		// Setup expectations for bulk flags processing
 		var expectedCacheKeys []string
 		for _, flag := range flags {
 			cacheKey := flagCacheKey(flag.Key)
 			expectedCacheKeys = append(expectedCacheKeys, cacheKey)
-			mockFlagCache.On("Set", mock.Anything, cacheKey, flag, 5*time.Minute).Return(nil)
+			h.flagCache.On("Set", mock.Anything, cacheKey, flag, 5*time.Minute).Return(nil)
 		}
+		h.flagCache.On("DeleteMissing", mock.Anything, expectedCacheKeys).Return(nil)
 
-		// Important: Bulk flags processing should call DeleteMissing
-		mockFlagCache.On("DeleteMissing", mock.Anything, expectedCacheKeys).Return(nil)
-
-		// Execute test
 		ctx := context.Background()
-		err = handler.HandleMessage(ctx, message)
-
-		// Verify results
+		err = h.handler.HandleMessage(ctx, message)
 		assert.NoError(t, err)
-
-		// Verify mock expectations - this ensures DeleteMissing was called for bulk processing
-		mockFlagCache.AssertExpectations(t)
+		h.flagCache.AssertExpectations(t)
 	})
 }
 
 func TestReplicatorMessageHandler_SingleVsBulkFlagProcessing(t *testing.T) {
 	t.Run("Single flag processing does NOT call DeleteMissing", func(t *testing.T) {
-		// Create mocks
-		logger := NewSchematicLogger()
-		mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-		mockCompanyLookupCache := NewMockCacheProvider[string]()
-		mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-		mockUserLookupCache := NewMockCacheProvider[string]()
-		mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+		h := newTestHarness(t)
 
-		// Create handler
-		handler := NewReplicatorMessageHandler(
-			logger,
-			mockCompanyCache,
-			mockCompanyLookupCache,
-			mockUserCache,
-			mockUserLookupCache,
-			mockFlagCache,
-			5*time.Minute,
-		)
-
-		// Single flag message
 		flag := createTestFlag(t)
 		flagData, err := json.Marshal(flag)
 		assert.NoError(t, err)
@@ -513,109 +423,66 @@ func TestReplicatorMessageHandler_SingleVsBulkFlagProcessing(t *testing.T) {
 			Data:        json.RawMessage(flagData),
 		}
 
-		// Setup expectations - only Set, no DeleteMissing
 		cacheKey := flagCacheKey(flag.Key)
-		mockFlagCache.On("Set", mock.Anything, cacheKey, flag, 5*time.Minute).Return(nil)
-		// Note: We don't set up DeleteMissing expectation - it should NOT be called
+		h.flagCache.On("Set", mock.Anything, cacheKey, flag, 5*time.Minute).Return(nil)
 
-		// Execute test
 		ctx := context.Background()
-		err = handler.HandleMessage(ctx, message)
-
-		// Verify results
+		err = h.handler.HandleMessage(ctx, message)
 		assert.NoError(t, err)
-
-		// Verify mock expectations - ensures DeleteMissing was NOT called
-		mockFlagCache.AssertExpectations(t)
+		h.flagCache.AssertExpectations(t)
 	})
 }
 
 func TestPartialCompanyMergesWithExistingCache(t *testing.T) {
-	logger := NewSchematicLogger()
-	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-	mockCompanyLookupCache := NewMockCacheProvider[string]()
-	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-	mockUserLookupCache := NewMockCacheProvider[string]()
-	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+	h := newTestHarness(t)
 
-	handler := NewReplicatorMessageHandler(
-		logger,
-		mockCompanyCache,
-		mockCompanyLookupCache,
-		mockUserCache,
-		mockUserLookupCache,
-		mockFlagCache,
-		5*time.Minute,
-	)
-
-	// Existing company in cache
 	existing := createTestCompany(t)
 	idKey := companyIDCacheKey(existing.ID)
-	mockCompanyCache.On("Get", mock.Anything, idKey).Return(existing, nil)
+	h.companyCache.On("Get", mock.Anything, idKey).Return(existing, nil)
 
-	// Partial: only update traits
 	partialData := json.RawMessage(`{"id":"company-123","traits":[{"value":"Startup","trait_definition":{"id":"plan","entity_type":"company"}}]}`)
-
 	message := &schematicdatastreamws.DataStreamResp{
 		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
 		MessageType: schematicdatastreamws.MessageTypePartial,
 		Data:        partialData,
 	}
 
-	// Expect Set with merged company (traits updated, other fields preserved)
-	mockCompanyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
+	h.companyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
 		return c.ID == "company-123" &&
-			c.AccountID == "account-456" && // preserved from existing
-			c.EnvironmentID == "env-789" && // preserved from existing
+			c.AccountID == "account-456" &&
+			c.EnvironmentID == "env-789" &&
 			len(c.Traits) == 1 &&
-			c.Traits[0].Value == "Startup" && // updated
-			len(c.Keys) == 2 // preserved from existing
+			c.Traits[0].Value == "Startup" &&
+			len(c.Keys) == 2
 	}), 5*time.Minute).Return(nil)
 
 	for key, value := range existing.Keys {
 		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
-		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
+		h.companyLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
 	}
 
 	ctx := context.Background()
-	err := handler.HandleMessage(ctx, message)
+	err := h.handler.HandleMessage(ctx, message)
 	assert.NoError(t, err)
-	mockCompanyCache.AssertExpectations(t)
-	mockCompanyLookupCache.AssertExpectations(t)
+	h.companyCache.AssertExpectations(t)
+	h.companyLookupCache.AssertExpectations(t)
 }
 
 func TestPartialUserMergesWithExistingCache(t *testing.T) {
-	logger := NewSchematicLogger()
-	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-	mockCompanyLookupCache := NewMockCacheProvider[string]()
-	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-	mockUserLookupCache := NewMockCacheProvider[string]()
-	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
-
-	handler := NewReplicatorMessageHandler(
-		logger,
-		mockCompanyCache,
-		mockCompanyLookupCache,
-		mockUserCache,
-		mockUserLookupCache,
-		mockFlagCache,
-		5*time.Minute,
-	)
+	h := newTestHarness(t)
 
 	existing := createTestUser(t)
 	idKey := userIDCacheKey(existing.ID)
-	mockUserCache.On("Get", mock.Anything, idKey).Return(existing, nil)
+	h.userCache.On("Get", mock.Anything, idKey).Return(existing, nil)
 
-	// Partial: only update traits
 	partialData := json.RawMessage(`{"id":"user-123","traits":[{"value":"Free","trait_definition":{"id":"tier","entity_type":"user"}}]}`)
-
 	message := &schematicdatastreamws.DataStreamResp{
 		EntityType:  string(schematicdatastreamws.EntityTypeUser),
 		MessageType: schematicdatastreamws.MessageTypePartial,
 		Data:        partialData,
 	}
 
-	mockUserCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(u *rulesengine.User) bool {
+	h.userCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(u *rulesengine.User) bool {
 		return u.ID == "user-123" &&
 			u.AccountID == "account-456" &&
 			u.EnvironmentID == "env-789" &&
@@ -626,33 +493,18 @@ func TestPartialUserMergesWithExistingCache(t *testing.T) {
 
 	for key, value := range existing.Keys {
 		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
-		mockUserLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
+		h.userLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
 	}
 
 	ctx := context.Background()
-	err := handler.HandleMessage(ctx, message)
+	err := h.handler.HandleMessage(ctx, message)
 	assert.NoError(t, err)
-	mockUserCache.AssertExpectations(t)
-	mockUserLookupCache.AssertExpectations(t)
+	h.userCache.AssertExpectations(t)
+	h.userLookupCache.AssertExpectations(t)
 }
 
 func TestFullThenPartialCompany(t *testing.T) {
-	logger := NewSchematicLogger()
-	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-	mockCompanyLookupCache := NewMockCacheProvider[string]()
-	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-	mockUserLookupCache := NewMockCacheProvider[string]()
-	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
-
-	handler := NewReplicatorMessageHandler(
-		logger,
-		mockCompanyCache,
-		mockCompanyLookupCache,
-		mockUserCache,
-		mockUserLookupCache,
-		mockFlagCache,
-		5*time.Minute,
-	)
+	h := newTestHarness(t)
 
 	company := createTestCompany(t)
 	idKey := companyIDCacheKey(company.ID)
@@ -667,18 +519,18 @@ func TestFullThenPartialCompany(t *testing.T) {
 		Data:        json.RawMessage(fullData),
 	}
 
-	mockCompanyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
+	h.companyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
 	for key, value := range company.Keys {
 		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
-		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
+		h.companyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
 	}
 
 	ctx := context.Background()
-	err = handler.HandleMessage(ctx, fullMsg)
+	err = h.handler.HandleMessage(ctx, fullMsg)
 	assert.NoError(t, err)
 
 	// Step 2: Partial message — Get returns the full company
-	mockCompanyCache.On("Get", mock.Anything, idKey).Return(company, nil)
+	h.companyCache.On("Get", mock.Anything, idKey).Return(company, nil)
 
 	partialData := json.RawMessage(`{"id":"company-123","traits":[]}`)
 	partialMsg := &schematicdatastreamws.DataStreamResp{
@@ -687,40 +539,25 @@ func TestFullThenPartialCompany(t *testing.T) {
 		Data:        partialData,
 	}
 
-	mockCompanyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
+	h.companyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
 		return c.ID == "company-123" &&
 			c.AccountID == "account-456" &&
-			len(c.Traits) == 0 && // cleared by partial
-			len(c.Keys) == 2 // preserved
+			len(c.Traits) == 0 &&
+			len(c.Keys) == 2
 	}), 5*time.Minute).Return(nil).Once()
 
-	err = handler.HandleMessage(ctx, partialMsg)
+	err = h.handler.HandleMessage(ctx, partialMsg)
 	assert.NoError(t, err)
-	mockCompanyCache.AssertExpectations(t)
+	h.companyCache.AssertExpectations(t)
 }
 
 func TestPartialThenFullCompany(t *testing.T) {
-	logger := NewSchematicLogger()
-	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
-	mockCompanyLookupCache := NewMockCacheProvider[string]()
-	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
-	mockUserLookupCache := NewMockCacheProvider[string]()
-	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
-
-	handler := NewReplicatorMessageHandler(
-		logger,
-		mockCompanyCache,
-		mockCompanyLookupCache,
-		mockUserCache,
-		mockUserLookupCache,
-		mockFlagCache,
-		5*time.Minute,
-	)
+	h := newTestHarness(t)
 
 	company := createTestCompany(t)
 	idKey := companyIDCacheKey(company.ID)
 
-	// Step 1: Partial with cache miss — writes as-is
+	// Step 1: Partial with cache miss — skipped
 	partialData := json.RawMessage(`{"id":"company-123","traits":[]}`)
 	partialMsg := &schematicdatastreamws.DataStreamResp{
 		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
@@ -729,11 +566,10 @@ func TestPartialThenFullCompany(t *testing.T) {
 	}
 
 	var nilCompany *rulesengine.Company
-	mockCompanyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found")).Once()
-	// Partial as-is has no keys, so cacheCompanyForKeys returns nil (no cache writes)
+	h.companyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found")).Once()
 
 	ctx := context.Background()
-	err := handler.HandleMessage(ctx, partialMsg)
+	err := h.handler.HandleMessage(ctx, partialMsg)
 	assert.NoError(t, err)
 
 	// Step 2: Full message overwrites everything
@@ -746,15 +582,15 @@ func TestPartialThenFullCompany(t *testing.T) {
 		Data:        json.RawMessage(fullData),
 	}
 
-	mockCompanyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
+	h.companyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
 	for key, value := range company.Keys {
 		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
-		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
+		h.companyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
 	}
 
-	err = handler.HandleMessage(ctx, fullMsg)
+	err = h.handler.HandleMessage(ctx, fullMsg)
 	assert.NoError(t, err)
-	mockCompanyCache.AssertExpectations(t)
+	h.companyCache.AssertExpectations(t)
 }
 
 // Test the convertToRulesEngineCompany function specifically for credit balance mapping

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -127,7 +128,7 @@ func TestReplicatorMessageHandler_HandleCompanyMessage(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Handle company update message",
+			name:        "Handle company partial message (no existing cache)",
 			messageType: schematicdatastreamws.MessageTypePartial,
 			company:     createTestCompany(t),
 			expectError: false,
@@ -173,15 +174,18 @@ func TestReplicatorMessageHandler_HandleCompanyMessage(t *testing.T) {
 
 			// Setup expectations
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
-				// For delete operations, expect Delete on ID key and lookup keys
 				idKey := companyIDCacheKey(tt.company.ID)
 				mockCompanyCache.On("Delete", mock.Anything, idKey).Return(nil)
 				for key, value := range tt.company.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
 					mockCompanyLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
 				}
+			} else if tt.messageType == schematicdatastreamws.MessageTypePartial {
+				// Partial with cache miss: expect Get (not found), skip without Set
+				idKey := companyIDCacheKey(tt.company.ID)
+				var nilCompany *rulesengine.Company
+				mockCompanyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found"))
 			} else {
-				// For create/update operations, expect Set on ID key and lookup keys
 				idKey := companyIDCacheKey(tt.company.ID)
 				mockCompanyCache.On("Set", mock.Anything, idKey, tt.company, 5*time.Minute).Return(nil)
 				for key, value := range tt.company.Keys {
@@ -222,7 +226,7 @@ func TestReplicatorMessageHandler_HandleUserMessage(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "Handle user update message",
+			name:        "Handle user partial message (no existing cache)",
 			messageType: schematicdatastreamws.MessageTypePartial,
 			user:        createTestUser(t),
 			expectError: false,
@@ -268,15 +272,18 @@ func TestReplicatorMessageHandler_HandleUserMessage(t *testing.T) {
 
 			// Setup expectations based on message type
 			if tt.messageType == schematicdatastreamws.MessageTypeDelete {
-				// For delete operations, expect Delete on ID key and lookup keys
 				idKey := userIDCacheKey(tt.user.ID)
 				mockUserCache.On("Delete", mock.Anything, idKey).Return(nil)
 				for key, value := range tt.user.Keys {
 					cacheKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
 					mockUserLookupCache.On("Delete", mock.Anything, cacheKey).Return(nil)
 				}
+			} else if tt.messageType == schematicdatastreamws.MessageTypePartial {
+				// Partial with cache miss: expect Get (not found), skip without Set
+				idKey := userIDCacheKey(tt.user.ID)
+				var nilUser *rulesengine.User
+				mockUserCache.On("Get", mock.Anything, idKey).Return(nilUser, fmt.Errorf("not found"))
 			} else {
-				// For create/update operations, expect Set on ID key and lookup keys
 				idKey := userIDCacheKey(tt.user.ID)
 				mockUserCache.On("Set", mock.Anything, idKey, tt.user, 5*time.Minute).Return(nil)
 				for key, value := range tt.user.Keys {
@@ -521,6 +528,233 @@ func TestReplicatorMessageHandler_SingleVsBulkFlagProcessing(t *testing.T) {
 		// Verify mock expectations - ensures DeleteMissing was NOT called
 		mockFlagCache.AssertExpectations(t)
 	})
+}
+
+func TestPartialCompanyMergesWithExistingCache(t *testing.T) {
+	logger := NewSchematicLogger()
+	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
+	mockCompanyLookupCache := NewMockCacheProvider[string]()
+	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
+	mockUserLookupCache := NewMockCacheProvider[string]()
+	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+
+	handler := NewReplicatorMessageHandler(
+		logger,
+		mockCompanyCache,
+		mockCompanyLookupCache,
+		mockUserCache,
+		mockUserLookupCache,
+		mockFlagCache,
+		5*time.Minute,
+	)
+
+	// Existing company in cache
+	existing := createTestCompany(t)
+	idKey := companyIDCacheKey(existing.ID)
+	mockCompanyCache.On("Get", mock.Anything, idKey).Return(existing, nil)
+
+	// Partial: only update traits
+	partialData := json.RawMessage(`{"id":"company-123","traits":[{"value":"Startup","trait_definition":{"id":"plan","entity_type":"company"}}]}`)
+
+	message := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
+		MessageType: schematicdatastreamws.MessageTypePartial,
+		Data:        partialData,
+	}
+
+	// Expect Set with merged company (traits updated, other fields preserved)
+	mockCompanyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
+		return c.ID == "company-123" &&
+			c.AccountID == "account-456" && // preserved from existing
+			c.EnvironmentID == "env-789" && // preserved from existing
+			len(c.Traits) == 1 &&
+			c.Traits[0].Value == "Startup" && // updated
+			len(c.Keys) == 2 // preserved from existing
+	}), 5*time.Minute).Return(nil)
+
+	for key, value := range existing.Keys {
+		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
+		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
+	}
+
+	ctx := context.Background()
+	err := handler.HandleMessage(ctx, message)
+	assert.NoError(t, err)
+	mockCompanyCache.AssertExpectations(t)
+	mockCompanyLookupCache.AssertExpectations(t)
+}
+
+func TestPartialUserMergesWithExistingCache(t *testing.T) {
+	logger := NewSchematicLogger()
+	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
+	mockCompanyLookupCache := NewMockCacheProvider[string]()
+	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
+	mockUserLookupCache := NewMockCacheProvider[string]()
+	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+
+	handler := NewReplicatorMessageHandler(
+		logger,
+		mockCompanyCache,
+		mockCompanyLookupCache,
+		mockUserCache,
+		mockUserLookupCache,
+		mockFlagCache,
+		5*time.Minute,
+	)
+
+	existing := createTestUser(t)
+	idKey := userIDCacheKey(existing.ID)
+	mockUserCache.On("Get", mock.Anything, idKey).Return(existing, nil)
+
+	// Partial: only update traits
+	partialData := json.RawMessage(`{"id":"user-123","traits":[{"value":"Free","trait_definition":{"id":"tier","entity_type":"user"}}]}`)
+
+	message := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeUser),
+		MessageType: schematicdatastreamws.MessageTypePartial,
+		Data:        partialData,
+	}
+
+	mockUserCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(u *rulesengine.User) bool {
+		return u.ID == "user-123" &&
+			u.AccountID == "account-456" &&
+			u.EnvironmentID == "env-789" &&
+			len(u.Traits) == 1 &&
+			u.Traits[0].Value == "Free" &&
+			len(u.Keys) == 2
+	}), 5*time.Minute).Return(nil)
+
+	for key, value := range existing.Keys {
+		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixUser, key, value)
+		mockUserLookupCache.On("Set", mock.Anything, cacheKey, existing.ID, 5*time.Minute).Return(nil)
+	}
+
+	ctx := context.Background()
+	err := handler.HandleMessage(ctx, message)
+	assert.NoError(t, err)
+	mockUserCache.AssertExpectations(t)
+	mockUserLookupCache.AssertExpectations(t)
+}
+
+func TestFullThenPartialCompany(t *testing.T) {
+	logger := NewSchematicLogger()
+	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
+	mockCompanyLookupCache := NewMockCacheProvider[string]()
+	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
+	mockUserLookupCache := NewMockCacheProvider[string]()
+	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+
+	handler := NewReplicatorMessageHandler(
+		logger,
+		mockCompanyCache,
+		mockCompanyLookupCache,
+		mockUserCache,
+		mockUserLookupCache,
+		mockFlagCache,
+		5*time.Minute,
+	)
+
+	company := createTestCompany(t)
+	idKey := companyIDCacheKey(company.ID)
+
+	// Step 1: Full message
+	fullData, err := json.Marshal(company)
+	assert.NoError(t, err)
+
+	fullMsg := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
+		MessageType: schematicdatastreamws.MessageTypeFull,
+		Data:        json.RawMessage(fullData),
+	}
+
+	mockCompanyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
+	for key, value := range company.Keys {
+		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
+		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
+	}
+
+	ctx := context.Background()
+	err = handler.HandleMessage(ctx, fullMsg)
+	assert.NoError(t, err)
+
+	// Step 2: Partial message — Get returns the full company
+	mockCompanyCache.On("Get", mock.Anything, idKey).Return(company, nil)
+
+	partialData := json.RawMessage(`{"id":"company-123","traits":[]}`)
+	partialMsg := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
+		MessageType: schematicdatastreamws.MessageTypePartial,
+		Data:        partialData,
+	}
+
+	mockCompanyCache.On("Set", mock.Anything, idKey, mock.MatchedBy(func(c *rulesengine.Company) bool {
+		return c.ID == "company-123" &&
+			c.AccountID == "account-456" &&
+			len(c.Traits) == 0 && // cleared by partial
+			len(c.Keys) == 2 // preserved
+	}), 5*time.Minute).Return(nil).Once()
+
+	err = handler.HandleMessage(ctx, partialMsg)
+	assert.NoError(t, err)
+	mockCompanyCache.AssertExpectations(t)
+}
+
+func TestPartialThenFullCompany(t *testing.T) {
+	logger := NewSchematicLogger()
+	mockCompanyCache := NewMockCacheProvider[*rulesengine.Company]()
+	mockCompanyLookupCache := NewMockCacheProvider[string]()
+	mockUserCache := NewMockCacheProvider[*rulesengine.User]()
+	mockUserLookupCache := NewMockCacheProvider[string]()
+	mockFlagCache := NewMockCacheProvider[*rulesengine.Flag]()
+
+	handler := NewReplicatorMessageHandler(
+		logger,
+		mockCompanyCache,
+		mockCompanyLookupCache,
+		mockUserCache,
+		mockUserLookupCache,
+		mockFlagCache,
+		5*time.Minute,
+	)
+
+	company := createTestCompany(t)
+	idKey := companyIDCacheKey(company.ID)
+
+	// Step 1: Partial with cache miss — writes as-is
+	partialData := json.RawMessage(`{"id":"company-123","traits":[]}`)
+	partialMsg := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
+		MessageType: schematicdatastreamws.MessageTypePartial,
+		Data:        partialData,
+	}
+
+	var nilCompany *rulesengine.Company
+	mockCompanyCache.On("Get", mock.Anything, idKey).Return(nilCompany, fmt.Errorf("not found")).Once()
+	// Partial as-is has no keys, so cacheCompanyForKeys returns nil (no cache writes)
+
+	ctx := context.Background()
+	err := handler.HandleMessage(ctx, partialMsg)
+	assert.NoError(t, err)
+
+	// Step 2: Full message overwrites everything
+	fullData, err := json.Marshal(company)
+	assert.NoError(t, err)
+
+	fullMsg := &schematicdatastreamws.DataStreamResp{
+		EntityType:  string(schematicdatastreamws.EntityTypeCompany),
+		MessageType: schematicdatastreamws.MessageTypeFull,
+		Data:        json.RawMessage(fullData),
+	}
+
+	mockCompanyCache.On("Set", mock.Anything, idKey, company, 5*time.Minute).Return(nil).Once()
+	for key, value := range company.Keys {
+		cacheKey := resourceKeyToCacheKey(cacheKeyPrefixCompany, key, value)
+		mockCompanyLookupCache.On("Set", mock.Anything, cacheKey, company.ID, 5*time.Minute).Return(nil)
+	}
+
+	err = handler.HandleMessage(ctx, fullMsg)
+	assert.NoError(t, err)
+	mockCompanyCache.AssertExpectations(t)
 }
 
 // Test the convertToRulesEngineCompany function specifically for credit balance mapping


### PR DESCRIPTION
Re-use PartialCompany/PartialUser from schematic-go/datastream

On cache miss for partial messages, log a warning
and skip rather than writing incomplete data. Remove dead pre-merge
unmarshal code. Update go.mod to schematic-go@f539b4e (main HEAD).