### PR TITLE
Bump go version to 1.26.1

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 ARG REVISION
 
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS builder
 
 # Install security updates and build dependencies
 RUN apk update && apk add --no-cache \

--- a/deployments/Dockerfile.single-arch
+++ b/deployments/Dockerfile.single-arch
@@ -8,7 +8,7 @@ ARG VERSION
 ARG REVISION
 
 # Build stage - native architecture only
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.1-alpine AS builder
 
 # Install security updates and build dependencies
 RUN apk update && apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/schematichq/schematic-datastream-replicator
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0


### PR DESCRIPTION
fixes [https://app.fencer.dev/a/schematic/vulnerabilities/grouped/?filters=%5B%7B'k':'status','op':'is_not','v':%5B'resolved'%5D%7D,%7B'k':'ignored','op':'is','v':%5B'false'%5D%7D,%7B'k':'deferred','op':'is','v':%5B'false'%5D%7D%5D#split=eJyrViotylGyUtJP1C9OzkjNTSzJTNYvK83JSy1KTMrMySzJTC3WTy/KLy1ITdE3szAyNNNX0lHKTAFqAfOAnILEotS8Ek+gUF5pTk4tAIA0Guc=&drawer=eJxNjMEKwjAQBX9F1mtKwCq0uSqepF5s7zFdcWFdJdkIpfTfjbceHzPzZqB0/aCA05jRgJIygoMhs2D0d2LSaXNC9cQJDOTIhVpvU3jiyysF+12phMkO/aWrzt3tuDvYUiRkDFqi7VqcqvAWRdFiPDJzChFR+v+7lGlg9OrBzUAjuH3bNG1dN8vyA/obO+I=](https://app.fencer.dev/a/schematic/vulnerabilities/VULN-FNTC25/)