### PR TITLE
Remove curl from the runtime image to clear Alpine package CVEs

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -46,7 +46,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
     -o schematic-datastream-replicator \
     .
 
-# Runtime stage using Alpine for minimal attack surface with built-in curl
+# Runtime stage using Alpine for minimal attack surface
 FROM alpine:3.24
 
 # Re-declare build args for runtime stage
@@ -58,8 +58,12 @@ ARG REVISION
 ARG HEALTH_PORT=8090
 ENV HEALTH_PORT=${HEALTH_PORT}
 
-# Install curl and ca-certificates for health checks
-RUN apk add --no-cache curl ca-certificates
+# Apply outstanding base-image security patches and install ca-certificates for
+# outbound TLS. Deliberately no curl: it pulls in libcurl, c-ares, nghttp2 and
+# five more transitive packages, which historically account for nearly every CVE
+# reported against this image. Health checks use the binary's own `healthcheck`
+# subcommand instead (Kubernetes probes use httpGet and never needed curl).
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 
 # Copy the binary from builder stage
 COPY --from=builder /app/schematic-datastream-replicator /app/schematic-datastream-replicator

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - REDIS_DB=${REDIS_DB:-0}
     healthcheck:
-        test: ["CMD-SHELL", "curl -f http://localhost:8090/health || exit 1"]
+        test: ["CMD", "/app/schematic-datastream-replicator", "healthcheck"]
         interval: 10s
         timeout: 10s
         retries: 3
@@ -56,9 +56,11 @@ services:
       - /tmp:noexec,nosuid,size=10m
     networks:
       - replicator-network
-    # External health check - use HTTP endpoints from outside the container
+    # In-container health check uses the binary's own `healthcheck` subcommand,
+    # so the image doesn't need curl installed. Pass `/ready` as an argument to
+    # probe readiness instead of liveness.
     # For Kubernetes: configure liveness/readiness probes to use /health and /ready endpoints
-    # For development: monitor via curl http://localhost:${HEALTH_PORT:-8090}/health
+    # For development: monitor via curl http://localhost:${HEALTH_PORT:-8090}/health from the host
 
   redis:
     image: redis:7-alpine

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -317,7 +317,7 @@ VERBOSE=true ./health-check.sh
 #### Docker Swarm
 ```yaml
 healthcheck:
-  test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8090/health"]
+  test: ["CMD", "/app/schematic-datastream-replicator", "healthcheck"]
   interval: 30s
   timeout: 10s
   retries: 3
@@ -431,6 +431,23 @@ curl http://localhost:8090/health
 # Check if service is ready to receive traffic
 curl http://localhost:8090/ready
 ```
+
+### Checking from inside the container
+
+The runtime image ships no HTTP client — `curl` and its dependency chain were
+removed because they accounted for nearly every CVE reported against the image.
+The binary probes itself instead, exiting 0 when the endpoint returns 200:
+
+```bash
+# Liveness (defaults to /health)
+docker exec <container> /app/schematic-datastream-replicator healthcheck
+
+# Readiness
+docker exec <container> /app/schematic-datastream-replicator healthcheck /ready
+```
+
+It honors `HEALTH_PORT`, so it follows a non-default port automatically.
+Kubernetes probes use `httpGet` and need nothing installed in the image.
 
 Response format:
 ```json

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthPortFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int
+	}{
+		{"unset falls back to default", "", defaultHealthPort},
+		{"valid port is used", "9090", 9090},
+		{"unparseable falls back to default", "not-a-port", defaultHealthPort},
+		{"zero falls back to default", "0", defaultHealthPort},
+		{"negative falls back to default", "-1", defaultHealthPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("HEALTH_PORT", tt.envValue)
+			}
+			assert.Equal(t, tt.expected, healthPortFromEnv())
+		})
+	}
+}
+
+// startProbeTarget stands up a server on 127.0.0.1 that answers with the given
+// status, and points HEALTH_PORT at it so runHealthCheck finds it.
+func startProbeTarget(t *testing.T, status int) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+
+	parsed, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	t.Setenv("HEALTH_PORT", parsed.Port())
+}
+
+func TestRunHealthCheck(t *testing.T) {
+	t.Run("healthy endpoint exits zero", func(t *testing.T) {
+		startProbeTarget(t, http.StatusOK)
+		assert.Equal(t, 0, runHealthCheck("/health"))
+	})
+
+	t.Run("not-ready endpoint exits non-zero", func(t *testing.T) {
+		// /ready returns 503 until the datastream has loaded initial data.
+		startProbeTarget(t, http.StatusServiceUnavailable)
+		assert.Equal(t, 1, runHealthCheck("/ready"))
+	})
+
+	t.Run("unreachable server exits non-zero", func(t *testing.T) {
+		// Bind and immediately release a port so nothing is listening on it.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		parsed, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+		srv.Close()
+
+		t.Setenv("HEALTH_PORT", parsed.Port())
+
+		assert.Equal(t, 1, runHealthCheck("/health"))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ const (
 	defaultCacheTTL             = 0 * time.Second // Unlimited cache by default
 	defaultCacheCleanupInterval = 1 * time.Hour   // Clean up stale cache entries every hour
 	defaultHealthPort           = 8090
+	healthCheckTimeout          = 5 * time.Second // Timeout for the self-health-check probe
 	cacheKeyPrefix              = "schematic"
 	cacheKeyPrefixCompany       = "company"
 	cacheKeyPrefixUser          = "user"
@@ -324,7 +325,50 @@ func (hs *HealthServer) readinessHandler(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// healthPortFromEnv reads the health server port, falling back to the default
+// when HEALTH_PORT is unset or unparseable.
+func healthPortFromEnv() int {
+	if portStr := os.Getenv("HEALTH_PORT"); portStr != "" {
+		if parsedPort, err := strconv.Atoi(portStr); err == nil && parsedPort > 0 {
+			return parsedPort
+		}
+	}
+	return defaultHealthPort
+}
+
+// runHealthCheck probes an endpoint on the local health server and reports the
+// exit code the process should use. It lets a container health-check itself, so
+// the runtime image doesn't need to ship curl and its dependency chain.
+func runHealthCheck(path string) int {
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", healthPortFromEnv(), path)
+
+	client := &http.Client{Timeout: healthCheckTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "health check failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "health check failed: %s returned %d\n", url, resp.StatusCode)
+		return 1
+	}
+
+	return 0
+}
+
 func main() {
+
+	// Self-check mode: `schematic-datastream-replicator healthcheck [path]`.
+	// Handled before any other setup so it stays a cheap, dependency-free probe.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		path := "/health"
+		if len(os.Args) > 2 {
+			path = os.Args[2]
+		}
+		os.Exit(runHealthCheck(path))
+	}
 
 	// Get API key from environment
 	apiKey := os.Getenv(apiKeyEnvVar)
@@ -384,12 +428,7 @@ func main() {
 	}
 
 	// Get health server port from environment
-	healthPort := defaultHealthPort
-	if portStr := os.Getenv("HEALTH_PORT"); portStr != "" {
-		if parsedPort, err := strconv.Atoi(portStr); err == nil && parsedPort > 0 {
-			healthPort = parsedPort
-		}
-	}
+	healthPort := healthPortFromEnv()
 
 	// Configure WebSocket options early so we can populate them as we parse environment variables
 	wsOptions := schematicdatastreamws.ClientOptions{


### PR DESCRIPTION
fixes https://app.fencer.dev/a/schematic/vulnerabilities/VULN-12HQ/

curl was in the runtime image only to service the docker-compose healthcheck, but it pulls in libcurl, c-ares, nghttp2 and six more transitive packages. Those accounted for 20 of the 21 OS CVEs on the published image, including all 8 criticals. Kubernetes probes use `httpGet` and never needed it.

Drops curl and replaces it with a `healthcheck` subcommand on the binary, which probes the local health server and exits non-zero on a non-200 or connection failure. Adds `apk upgrade` so base patches land at build time.

Grype on the rebuilt image, both arches: 1 remaining finding, CVE-2025-60876 in busybox, which has no upstream fix.