### PR TITLE
chore(deps): stop dependabot proposing golang rc base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,14 @@ updates:
     labels:
       - "docker"
       - "Dependabot"
+    ignore:
+      # Go ships release candidates as bare-suffix tags (golang:1.27rc2), which
+      # Dependabot ranks as a plain minor bump of the builder pin. Globs like
+      # "*rc*" are NOT the fix: the docker ecosystem parses ignore.versions as a
+      # Bundler requirement, so a glob is a hard validation error that disables
+      # this whole file. Gating the minor works because it expands to
+      # ">= 1.27.a, < 2", and the ".a" is what catches 1.27rc2. Patch bumps (the
+      # CVE ones) still come through; stable minors become a manual FROM edit to
+      # deployments/Dockerfile and Dockerfile.single-arch.
+      - dependency-name: "golang"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
Same fix as SchematicHQ/asynqmon#62 and SchematicHQ/schematic-api#7357. A survey of all 49 non-archived SchematicHQ repos found this is the third and last repo with the gap: `deployments/Dockerfile` and `deployments/Dockerfile.single-arch` both pin `FROM golang:1.26.5-alpine`, the `docker` ecosystem entry covers `/deployments`, and there was no `ignore` block.

Go publishes release candidates as bare-suffix tags (`golang:1.27rc2`), so Dependabot ranks them as an ordinary minor bump of the pinned tag rather than a prerelease. This repo hasn't received such a PR yet — its docker schedule is `weekly` rather than `daily`, which is probably all that has spared it. asynqmon got `1.27rc2` (#61), `1.26rc2` (#33) and `1.26rc3` (#38); schematic-api got `1.27rc3` (#7333) and `1.27rc2` (#6433). All closed unmerged.

The obvious fix — `versions: ["*rc*", "*beta*"]` — is wrong and would make things worse. For the `docker` ecosystem, `ignore.versions` is parsed as a Bundler requirement ([`docker/requirement.rb`](https://github.com/dependabot/dependabot-core/blob/main/docker/lib/dependabot/docker/requirement.rb) subclasses `Gem::Requirement`, whose `PATTERN` requires a leading digit), so a glob raises `BadRequirementError`, GitHub rejects the file, and **every ecosystem in it stops updating** — gomod and github-actions included. See [atc0005/go-ci#542](https://github.com/atc0005/go-ci/issues/542), [dependabot-core#8677](https://github.com/dependabot/dependabot-core/issues/8677) (uses literally `versions: ["*rc*"]` on `golang`), and [#15154](https://github.com/dependabot/dependabot-core/issues/15154).

`versions: [">= 1.27"]` parses but is ineffective — `Gem::Version` sorts prereleases *below* the release ([#9007](https://github.com/dependabot/dependabot-core/issues/9007)).

`update-types` works because [`IgnoreCondition#versions_by_type`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/config/ignore_condition.rb) expands `semver-minor` to `>= 1.27.a, < 2`, appending `lowest_prerelease_suffix`. That trailing `.a` is what pulls `1.27rc2` inside the ignore.

Trade-off: stable minors are suppressed too, so `1.26 → 1.27.0` becomes a manual edit to both Dockerfiles. Patch bumps still flow, which is where Go's CVE fixes arrive.

## Verification

- Config-only; no Go source touched, so build/vet/test don't apply.
- Parses as YAML and validates against the [SchemaStore dependabot-2.0 schema](https://json.schemastore.org/dependabot-2.0.json); all 3 ecosystem entries survive and both `update-types` values are in the documented enum.
- Sharp edge worth recording: the glob form **also** passes that JSON schema. Only the Bundler parse rejects it, which is why this mistake reaches production config uncaught.
- Not verified locally: no ruby available on the machine this was authored on, so the `Gem::Requirement` semantics are cited from dependabot-core source and upstream issues rather than re-run. Real proof is the next weekly docker run after merge — confirm a `golang` *patch* bump still opens, since a mistake here surfaces as silence rather than an error.